### PR TITLE
Add tests, consistently use tabs vs spaces, PEP-8 naming

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,3 +3,6 @@ PROJECT=petname
 clean:
 	rm -rf MANIFEST dist/* $(PROJECT).egg-info .coverage build/*
 	find . -name '*.pyc' -delete
+
+test:
+	python -m unittest

--- a/petname/__init__.py
+++ b/petname/__init__.py
@@ -20,37 +20,44 @@ import random
 from .english import adverbs, adjectives, names
 
 
-def Adverb(letters=6):
-	while 1:
-		w = random.choice(adverbs)
-		if len(w) <= letters:
-			return w
+def adverb(letters=6):
+    while 1:
+        w = random.choice(adverbs)
+        if len(w) <= letters:
+            return w
 
 
-def Adjective(letters=6):
-	while 1:
-		w = random.choice(adjectives)
-		if len(w) <= letters:
-			return w
+def adjective(letters=6):
+    while 1:
+        w = random.choice(adjectives)
+        if len(w) <= letters:
+            return w
 
 
-def Name(letters=6):
-	while 1:
-		w = random.choice(names)
-		if len(w) <= letters:
-			return w
+def name(letters=6):
+    while 1:
+        w = random.choice(names)
+        if len(w) <= letters:
+            return w
 
 
-def Generate(words, separator, letters=6):
-	if letters < 3:
-		letters = 3
-	if words == 1:
-		return Name(letters)
-	elif words == 2:
-		return Adjective(letters) + separator + Name(letters)
-	petname = []
-	for i in range(0, words - 2):
-		petname.append(Adverb(letters))
-		petname.append(Adjective(letters))
-		petname.append(Name(letters))
-	return separator.join(petname)
+def generate(words, separator, letters=6):
+    if letters < 3:
+        letters = 3
+    if words == 1:
+        return name(letters)
+    elif words == 2:
+        return adjective(letters) + separator + name(letters)
+    petname = []
+    for i in range(0, words - 2):
+        petname.append(adverb(letters))
+        petname.append(adjective(letters))
+        petname.append(name(letters))
+    return separator.join(petname)
+
+
+# aliases for backwards compatiblity
+Adverb = adverb
+Adjective = adjective
+Name = name
+Generate = generate

--- a/petname/__init__.py
+++ b/petname/__init__.py
@@ -21,39 +21,39 @@ from .english import adverbs, adjectives, names
 
 
 def adverb(letters=6):
-    while 1:
-        w = random.choice(adverbs)
-        if len(w) <= letters:
-            return w
+	while 1:
+		w = random.choice(adverbs)
+		if len(w) <= letters:
+			return w
 
 
 def adjective(letters=6):
-    while 1:
-        w = random.choice(adjectives)
-        if len(w) <= letters:
-            return w
+	while 1:
+		w = random.choice(adjectives)
+		if len(w) <= letters:
+			return w
 
 
 def name(letters=6):
-    while 1:
-        w = random.choice(names)
-        if len(w) <= letters:
-            return w
+	while 1:
+		w = random.choice(names)
+		if len(w) <= letters:
+			return w
 
 
 def generate(words, separator, letters=6):
-    if letters < 3:
-        letters = 3
-    if words == 1:
-        return name(letters)
-    elif words == 2:
-        return adjective(letters) + separator + name(letters)
-    petname = []
-    for i in range(0, words - 2):
-        petname.append(adverb(letters))
-        petname.append(adjective(letters))
-        petname.append(name(letters))
-    return separator.join(petname)
+	if letters < 3:
+		letters = 3
+	if words == 1:
+		return name(letters)
+	elif words == 2:
+		return adjective(letters) + separator + name(letters)
+	petname = []
+	for i in range(0, words - 2):
+		petname.append(adverb(letters))
+		petname.append(adjective(letters))
+		petname.append(name(letters))
+	return separator.join(petname)
 
 
 # aliases for backwards compatiblity

--- a/petname/__main__.py
+++ b/petname/__main__.py
@@ -21,13 +21,13 @@ import petname
 import sys
 
 def main():
-    parser = argparse.ArgumentParser(description='Generate human readable random names')
-    parser.add_argument('-w', '--words', help='Number of words in name, default=2', default=2)
-    parser.add_argument('-l', '--letters', help='Maximum number of letters per word, default=6', default=6)
-    parser.add_argument('-s', '--separator', help='Separator between words, default="-"', default="-")
-    parser.options = parser.parse_args()
+	parser = argparse.ArgumentParser(description='Generate human readable random names')
+	parser.add_argument('-w', '--words', help='Number of words in name, default=2', default=2)
+	parser.add_argument('-l', '--letters', help='Maximum number of letters per word, default=6', default=6)
+	parser.add_argument('-s', '--separator', help='Separator between words, default="-"', default="-")
+	parser.options = parser.parse_args()
 
-    sys.stdout.write(petname.Generate(int(parser.options.words), parser.options.separator, int(parser.options.letters)) + "\n")
+	sys.stdout.write(petname.Generate(int(parser.options.words), parser.options.separator, int(parser.options.letters)) + "\n")
 
 if __name__ == "__main__":
-    main()
+	main()

--- a/setup.py
+++ b/setup.py
@@ -20,25 +20,25 @@ import os
 from setuptools import setup
 
 try:
-    readme = open(os.path.join(os.path.dirname(__file__), "README.md")).read()
+	readme = open(os.path.join(os.path.dirname(__file__), "README.md")).read()
 except:
-    readme = "See: http://pypi.python.org/pypi?name=petname&:action=display_pkginfo"
+	readme = "See: http://pypi.python.org/pypi?name=petname&:action=display_pkginfo"
 
 setup(
-    name='petname',
-    description='Generate human-readable, random object names',
-    long_description=readme,
-    version='2.1',
-    author='Dustin Kirkland',
-    author_email='dustin.kirkland@gmail.com',
-    license="Apache2",
-    keywords="random name uuid",
-    url='https://launchpad.net/petname',
-    platforms=['any'],
-    packages=['petname'],
-    entry_points={
-        'console_scripts': [
-            'petname = petname.__main__:main',
-        ]
-    },
+	name='petname',
+	description='Generate human-readable, random object names',
+	long_description=readme,
+	version='2.1',
+	author='Dustin Kirkland',
+	author_email='dustin.kirkland@gmail.com',
+	license="Apache2",
+	keywords="random name uuid",
+	url='https://launchpad.net/petname',
+	platforms=['any'],
+	packages=['petname'],
+	entry_points={
+		'console_scripts': [
+			'petname = petname.__main__:main',
+		]
+	},
 )

--- a/test.py
+++ b/test.py
@@ -5,51 +5,51 @@ import petname.english
 
 
 class TestAdjective(unittest.TestCase):
-    def test_works(self):
-        self.assertIn(petname.adjective(), petname.english.adjectives)
+	def test_works(self):
+		self.assertIn(petname.adjective(), petname.english.adjectives)
 
-    def test_alias(self):
-        self.assertIs(petname.adjective, petname.Adjective)
+	def test_alias(self):
+		self.assertIs(petname.adjective, petname.Adjective)
 
-    def test_len(self):
-        for l in range(4, 10):
-            self.assertLessEqual(len(petname.adjective(l)), l)
+	def test_len(self):
+		for l in range(4, 10):
+			self.assertLessEqual(len(petname.adjective(l)), l)
 
 
 class TestAdverb(unittest.TestCase):
-    def test_works(self):
-        self.assertIn(petname.adverb(), petname.english.adverbs)
+	def test_works(self):
+		self.assertIn(petname.adverb(), petname.english.adverbs)
 
-    def test_alias(self):
-        self.assertIs(petname.adverb, petname.Adverb)
+	def test_alias(self):
+		self.assertIs(petname.adverb, petname.Adverb)
 
-    def test_len(self):
-        for l in range(4, 10):
-            self.assertLessEqual(len(petname.adverb(l)), l)
+	def test_len(self):
+		for l in range(4, 10):
+			self.assertLessEqual(len(petname.adverb(l)), l)
 
 
 class TestName(unittest.TestCase):
-    def test_works(self):
-        self.assertIn(petname.name(), petname.english.names)
+	def test_works(self):
+		self.assertIn(petname.name(), petname.english.names)
 
-    def test_alias(self):
-        self.assertIs(petname.name, petname.Name)
+	def test_alias(self):
+		self.assertIs(petname.name, petname.Name)
 
-    def test_len(self):
-        for l in range(4, 10):
-            self.assertLessEqual(len(petname.name(l)), l)
+	def test_len(self):
+		for l in range(4, 10):
+			self.assertLessEqual(len(petname.name(l)), l)
 
 
 class TestGenerate(unittest.TestCase):
-    def test_works(self):
-        words = 3
-        sep = '-'
-        name = petname.generate(words, sep)
-        self.assertEqual(len(name.split(sep)), words)
+	def test_works(self):
+		words = 3
+		sep = '-'
+		name = petname.generate(words, sep)
+		self.assertEqual(len(name.split(sep)), words)
 
-    def test_alias(self):
-        self.assertIs(petname.generate, petname.Generate)
+	def test_alias(self):
+		self.assertIs(petname.generate, petname.Generate)
 
 
 if __name__ == '__main__':
-    unittest.main()
+	unittest.main()

--- a/test.py
+++ b/test.py
@@ -1,0 +1,55 @@
+import unittest
+
+import petname
+import petname.english
+
+
+class TestAdjective(unittest.TestCase):
+    def test_works(self):
+        self.assertIn(petname.adjective(), petname.english.adjectives)
+
+    def test_alias(self):
+        self.assertIs(petname.adjective, petname.Adjective)
+
+    def test_len(self):
+        for l in range(4, 10):
+            self.assertLessEqual(len(petname.adjective(l)), l)
+
+
+class TestAdverb(unittest.TestCase):
+    def test_works(self):
+        self.assertIn(petname.adverb(), petname.english.adverbs)
+
+    def test_alias(self):
+        self.assertIs(petname.adverb, petname.Adverb)
+
+    def test_len(self):
+        for l in range(4, 10):
+            self.assertLessEqual(len(petname.adverb(l)), l)
+
+
+class TestName(unittest.TestCase):
+    def test_works(self):
+        self.assertIn(petname.name(), petname.english.names)
+
+    def test_alias(self):
+        self.assertIs(petname.name, petname.Name)
+
+    def test_len(self):
+        for l in range(4, 10):
+            self.assertLessEqual(len(petname.name(l)), l)
+
+
+class TestGenerate(unittest.TestCase):
+    def test_works(self):
+        words = 3
+        sep = '-'
+        name = petname.generate(words, sep)
+        self.assertEqual(len(name.split(sep)), words)
+
+    def test_alias(self):
+        self.assertIs(petname.generate, petname.Generate)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Fixes #3 really this time?

I mean, I like spaces and so does Python, but can live with either. Better to just have *one* variant though: some Python files were spaces, some tabs.