### PR TITLE
Fix the readme for new GitHub markdown parsing

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,14 @@
-#petname
+# petname
 
-##NAME []()
+## NAME []()
 
 **petname** − a utility to generate "pet names", consisting of a random combination of adverbs, an adjective, and an animal name
 
-##SYNOPSIS []()
+## SYNOPSIS []()
 
 **petname** \[-w|--words INT\] \[-l|--letters INT\] \[-s|--separator STR\] \[-d|--dir STR\] \[-c|--complexity INT\] \[-u|--ubuntu\]
 
-##OPTIONS []()
+## OPTIONS []()
 - -w|--words number of words in the name, default is 2
 - -l|--letters maximum number of letters in each word, default is unlimited
 - -s|--separator string used to separate name words, default is ’-’
@@ -16,7 +16,7 @@
 - -c|--complexity \[0, 1, 2\]; 0 = easy words, 1 = standard words, 2 = complex words, default=1
 - -u|--ubuntu generate ubuntu-style names, alliteration of first character of each word
 
-##DESCRIPTION []()
+## DESCRIPTION []()
 
 This utility will generate "pet names", consisting of a random combination of an adverb, adjective, and an animal name. These are useful for unique hostnames or container names, for instance.
 
@@ -26,7 +26,7 @@ As such, PetName tries to follow the tenets of Zooko’s triangle. Names are:
 - decentralized
 - secure
 
-##EXAMPLES []()
+## EXAMPLES []()
 
 ```
 $ petname
@@ -54,7 +54,7 @@ $ petname --complexity 0
 massive-colt
 ```
 
-##CODE []()
+## CODE []()
 
 Besides this shell utility, there are also native libraries: python-petname, python3-petname, and golang-petname. Here are some programmatic examples in code:
 
@@ -98,7 +98,7 @@ parser.options = parser.parse_args()
 print petname.Generate(int(parser.options.words), parser.options.separator)
 ```
 
-##AUTHOR []()
+## AUTHOR []()
 
 This manpage and the utility were written by Dustin Kirkland &lt;dustin.kirkland@gmail.com&gt; for Ubuntu systems (but may be used by others). Permission is granted to copy, distribute and/or modify this document and the utility under the terms of the Apache2 License.
 


### PR DESCRIPTION
Just fixed the readme for the new GitHub markdown parsing, headings were broken.