### PR TITLE
Fix UnicodeDecodeError on install

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -19,8 +19,11 @@
 
 from setuptools import setup
 
-with open("README.md", "r") as fh:
-	long_description = fh.read()
+try:
+	with open("README.md", "r", encoding='utf-8') as fh:
+		long_description = fh.read()
+except UnicodeDecodeError:
+	long_description = str()
 
 setup(
 	name='petname',


### PR DESCRIPTION
Fixes #11. Bug was reproduced and tested in [`ubuntu:18.04`](https://github.com/tianon/docker-brew-ubuntu-core/blob/7145f9723125e6e4367dc0fb428ffd9f2bc00334/bionic/Dockerfile) Docker image with Python 3.6.9. Root cause is that locale in Ubuntu image is not set to UTF-8 by default, but IMHO this shouldn't be breaking installation just because of a README.