### PR TITLE
fix readme encoding

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -23,11 +23,11 @@ with open("README.md", "r", encoding="utf-8") as fh:
 	long_description = fh.read()
 
 setup(
-	name='petname',
+	name='petname-fork',
 	description='Generate human-readable, random object names',
 	#long_description=long_description,
 	#long_description_content_type="text/markdown",
-	version='2.7',
+	version='2.7p1',
 	author='Dustin Kirkland',
 	author_email='dustin.kirkland@gmail.com',
 	license="Apache2",

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@
 
 from setuptools import setup
 
-with open("README.md", "r") as fh:
+with open("README.md", "r", encoding="utf-8") as fh:
 	long_description = fh.read()
 
 setup(


### PR DESCRIPTION
Reading the README.md fails depending on the encoding of the shell. Eg, on a windows machine using gbk encoding, during `pip install`, you will see

```
UnicodeEncodeError: 'gbk' codec can't encode character
```

This PR forces the encoding to be utf-8.